### PR TITLE
Adds getRecordCount() to the Victims Database Interface. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .classpath
 .project
 .settings/
+target

--- a/src/main/java/com/redhat/victims/database/VictimsDBInterface.java
+++ b/src/main/java/com/redhat/victims/database/VictimsDBInterface.java
@@ -10,12 +10,12 @@ package com.redhat.victims.database;
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -32,7 +32,7 @@ public interface VictimsDBInterface {
 
 	/**
 	 * Returns when the database was successfully updated
-	 * 
+	 *
 	 * @return A {@link Date} object indicating when the last update was
 	 *         performed
 	 * @throws VictimsException
@@ -42,7 +42,7 @@ public interface VictimsDBInterface {
 	/**
 	 * Synchronizes the database with the changes fetched from the victi.ms
 	 * service.
-	 * 
+	 *
 	 * @throws VictimsException
 	 */
 	public void synchronize() throws VictimsException;
@@ -50,7 +50,7 @@ public interface VictimsDBInterface {
 	/**
 	 * Given a {@link VictimsRecord}, finds all CVEs that the artifact is
 	 * vulnerable to.
-	 * 
+	 *
 	 * @param vr
 	 * @return
 	 * @throws VictimsException
@@ -59,7 +59,7 @@ public interface VictimsDBInterface {
 			throws VictimsException;
 
 	/**
-	 * 
+	 *
 	 * @param sha512
 	 * @return
 	 * @throws VictimsException
@@ -69,7 +69,7 @@ public interface VictimsDBInterface {
 
 	/**
 	 * For a given set of properties match all CVEs that match.
-	 * 
+	 *
 	 * @param props
 	 *            A set of key/value pairs representing all meta properties to
 	 *            be matched.

--- a/src/main/java/com/redhat/victims/database/VictimsDBInterface.java
+++ b/src/main/java/com/redhat/victims/database/VictimsDBInterface.java
@@ -79,4 +79,11 @@ public interface VictimsDBInterface {
 	public HashSet<String> getVulnerabilities(HashMap<String, String> props)
 			throws VictimsException;
 
+	/**
+	 * Returns the number of records that exist within the Victims database.
+	 *
+	 * @return The number of records in the Victims Database
+	 * @throws VictimsException
+	 */
+	public int getRecordCount() throws VictimsException;
 }

--- a/src/main/java/com/redhat/victims/database/VictimsSQL.java
+++ b/src/main/java/com/redhat/victims/database/VictimsSQL.java
@@ -311,5 +311,6 @@ public class VictimsSQL {
 		protected final static String FILEHASH_COUNT_PER_RECORD = "SELECT record, count(*) FROM filehashes GROUP BY record";
 		protected final static String FILEHASHES = "SELECT record, filehash FROM filehashes";
 		protected final static String PROPERTY_MATCH = "SELECT record FROM meta WHERE prop = ? AND value = ?";
+		protected final static String RECORD_COUNT = "SELECT COUNT(*) from records";
 	}
 }

--- a/src/main/java/com/redhat/victims/database/VictimsSQL.java
+++ b/src/main/java/com/redhat/victims/database/VictimsSQL.java
@@ -10,12 +10,12 @@ package com.redhat.victims.database;
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -38,9 +38,9 @@ import com.redhat.victims.VictimsException;
 /**
  * This class implements SQL queries, connection managers and helper methods for
  * JDBC drivers.
- * 
+ *
  * @author abn
- * 
+ *
  */
 public class VictimsSQL {
 	private String dbDriver = null;
@@ -50,7 +50,7 @@ public class VictimsSQL {
 
 	/**
 	 * Get a new connection from the {@link VictimsSqlManager} pool.
-	 * 
+	 *
 	 * @return
 	 * @throws SQLException
 	 */
@@ -69,7 +69,7 @@ public class VictimsSQL {
 
 	/**
 	 * Initializes a database by created required tables.
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	protected void setUp() throws SQLException {
@@ -104,7 +104,7 @@ public class VictimsSQL {
 
 	/**
 	 * Wrapper to create a prepared statement.
-	 * 
+	 *
 	 * @param connection
 	 * @param query
 	 * @return
@@ -118,7 +118,7 @@ public class VictimsSQL {
 	/**
 	 * Give a query and list of objects to set, a prepared statement is created,
 	 * cached and returned with the objects set in the order they are provided.
-	 * 
+	 *
 	 * @param query
 	 * @param objects
 	 * @return
@@ -134,7 +134,7 @@ public class VictimsSQL {
 	/**
 	 * Helper function to set the values given, to a {@link PreparedStatement},
 	 * in the order in which they are given.
-	 * 
+	 *
 	 * @param ps
 	 * @param objects
 	 * @throws SQLException
@@ -151,7 +151,7 @@ public class VictimsSQL {
 	/**
 	 * Helper function to execute all pending patch operations in the given
 	 * {@link PreparedStatement}s and close it.
-	 * 
+	 *
 	 * @param preparedStatements
 	 * @throws SQLException
 	 */
@@ -168,7 +168,7 @@ public class VictimsSQL {
 	 * Given a an sql query containing the string "IN (?)" and a set of strings,
 	 * this method constructs a query by safely replacing the first occurence of
 	 * "IN (?)" with "IN ('v1','v2'...)", where v1,v2,.. are in values.
-	 * 
+	 *
 	 * @param query
 	 * @param values
 	 * @return
@@ -192,7 +192,7 @@ public class VictimsSQL {
 
 	/**
 	 * Given a hash get the first occurance's record id.
-	 * 
+	 *
 	 * @param hash
 	 * @return
 	 * @throws SQLException
@@ -221,7 +221,7 @@ public class VictimsSQL {
 
 	/**
 	 * Insert a new record with the given hash and return the record id.
-	 * 
+	 *
 	 * @param hash
 	 * @return A record id if it was created correctly, else return -1.
 	 * @throws SQLException
@@ -248,7 +248,7 @@ public class VictimsSQL {
 	/**
 	 * Remove records matching a given hash. This will cascade to all
 	 * references.
-	 * 
+	 *
 	 * @param hash
 	 * @throws SQLException
 	 */
@@ -269,9 +269,9 @@ public class VictimsSQL {
 
 	/**
 	 * This class defines SQL queries that are available.
-	 * 
+	 *
 	 * @author abn
-	 * 
+	 *
 	 */
 	protected static class Query {
 		protected final static String CREATE_TABLE_RECORDS = "CREATE TABLE records ( "

--- a/src/main/java/com/redhat/victims/database/VictimsSqlDB.java
+++ b/src/main/java/com/redhat/victims/database/VictimsSqlDB.java
@@ -401,6 +401,32 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 		}
 	}
 
+	public int getRecordCount() throws VictimsException {
+
+		int count = 0;
+		Connection connection = null;
+		Statement stmt = null;
+		try {
+			connection = getConnection();
+			stmt = connection.createStatement();
+			ResultSet resultSet = stmt.executeQuery(Query.RECORD_COUNT);
+			if (resultSet.next()){
+				count = resultSet.getInt(1);
+			}
+			resultSet.close();
+
+		} catch (SQLException e){
+			throw new VictimsException("Could not query database size", e);
+		} finally {
+			try {
+				if (stmt != null) stmt.close();
+				if (connection != null) connection.close();
+			} catch (Exception e){
+			}
+		}
+		return count;
+	}
+
 	/**
 	 * This class is used internally to store counts.
 	 *

--- a/src/main/java/com/redhat/victims/database/VictimsSqlDB.java
+++ b/src/main/java/com/redhat/victims/database/VictimsSqlDB.java
@@ -10,12 +10,12 @@ package com.redhat.victims.database;
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -48,9 +48,9 @@ import com.redhat.victims.fingerprint.Algorithms;
 
 /**
  * This class implements {@link VictimsDBInterface} for SQL databases.
- * 
+ *
  * @author abn
- * 
+ *
  */
 public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	// The default file for storing the last sync'ed {@link Date}
@@ -60,7 +60,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 
 	/**
 	 * Create a new instance with the given parameters.
-	 * 
+	 *
 	 * @param driver
 	 *            The driver class to use.
 	 * @param dbUrl
@@ -70,7 +70,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	 * @throws IOException
 	 * @throws ClassNotFoundException
 	 * @throws SQLException
-	 * @throws VictimsException 
+	 * @throws VictimsException
 	 */
 	public VictimsSqlDB() throws VictimsException {
 		super();
@@ -81,7 +81,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	/**
 	 * Remove all records matching the records in the given {@link RecordStream}
 	 * if it exists.
-	 * 
+	 *
 	 * @param recordStream
 	 * @throws SQLException
 	 * @throws IOException
@@ -104,7 +104,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	 * Update all records in the given {@link RecordStream}. This will remove
 	 * the record if it already exits and then add it. Otherwise, it just adds
 	 * it.
-	 * 
+	 *
 	 * @param recordStream
 	 * @throws SQLException
 	 * @throws IOException
@@ -154,7 +154,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	/**
 	 * Sets the last updated date. Once done, next call to lastUpdated() method
 	 * will return this date.
-	 * 
+	 *
 	 * @param date
 	 *            The date to set.
 	 * @throws IOException
@@ -239,7 +239,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 
 	/**
 	 * Returns CVEs that are ascociated with a given record id.
-	 * 
+	 *
 	 * @param recordId
 	 * @return
 	 * @throws SQLException
@@ -321,7 +321,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	/**
 	 * Fetch record id's from the local database that is composed entirely of
 	 * hashes in the set of hashes provided.
-	 * 
+	 *
 	 * @param hashes
 	 * @return A set record ids
 	 * @throws SQLException
@@ -360,7 +360,7 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 	 * Internal method implementing search for vulnerabilities checking if the
 	 * given {@link VictimsRecord}'s contents are a superset of a record in the
 	 * victims database.
-	 * 
+	 *
 	 * @param vr
 	 * @return
 	 * @throws SQLException
@@ -403,9 +403,9 @@ public class VictimsSqlDB extends VictimsSQL implements VictimsDBInterface {
 
 	/**
 	 * This class is used internally to store counts.
-	 * 
+	 *
 	 * @author abn
-	 * 
+	 *
 	 */
 	protected static class MutableInteger {
 		/*


### PR DESCRIPTION
This allows any callers to be able to check if the database is empty and been initialized correctly.
Presently the only way to do this is by relying on the lastUpdate and compare date returned to time(0) which is disconnected from the actual database state. 

Whilst this approach works I'm not sure it is 'the best' way to achieve this. For example you could do something similar to this that doesn't require the client to call this method explicitly. Maybe you could throw  an exception if the client attempts to perform a scan when the database has no entries ?
